### PR TITLE
feat: chart.js & chart-reactjs-2 add, chart edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "dependencies": {
     "@stitches/react": "^1.2.8",
     "axios": "^0.27.2",
+    "chart.js": "^3.9.1",
     "eslint-config-airbnb": "19.0.4",
     "husky": "^8.0.1",
     "next": "12.3.1",
     "prettier": "^2.7.1",
     "react": "18.2.0",
+    "react-chartjs-2": "^4.3.1",
     "react-dom": "18.2.0",
     "sass": "^1.54.9",
     "zustand": "^4.1.1"

--- a/src/component/atoms/Text/index.d.ts
+++ b/src/component/atoms/Text/index.d.ts
@@ -11,4 +11,5 @@ export interface Props<T> {
     css?: object;
     target?: Types['target'];
     position?: 'left' | 'right';
+    onClick?: () => void;
 }

--- a/src/component/atoms/Text/index.tsx
+++ b/src/component/atoms/Text/index.tsx
@@ -6,10 +6,10 @@ import { Text } from './style';
 // types
 import { Props } from './index.d';
 
-export const TextAtoms = <T,>({ text, textType, href, css, link, target, position }: Props<T>) => {
+export const TextAtoms = <T,>({ text, textType, href, css, link, target, position, onClick }: Props<T>) => {
     return (
         <>
-            <Text textType={textType} position={position} css={{ ...css }}>
+            <Text textType={textType} position={position} css={{ ...css }} onClick={onClick}>
                 {link ? (
                     <a href={href} target={target}>
                         {text}

--- a/src/component/molecules/DashBoardCardChart/DataColor.ts
+++ b/src/component/molecules/DashBoardCardChart/DataColor.ts
@@ -1,0 +1,47 @@
+interface DataColorType {}
+
+export const DataColor: DataColorType = [
+    {
+        name: 'typescript',
+        color: 'rgba(44, 109, 188, 0.6)',
+    },
+    {
+        name: 'javascript',
+        color: 'rgba(238, 219, 87, 0.6)',
+    },
+    {
+        name: 'scss',
+        color: 'rgba(192, 72, 129, 0.6)',
+    },
+    {
+        name: 'shell',
+        color: 'rgba(122, 220, 78, 0.6)',
+    },
+    {
+        name: 'css',
+        color: 'rgba(77, 53, 111, 0.6)',
+    },
+    {
+        name: 'html',
+        color: 'rgba(225, 66, 40, 0.6)',
+    },
+];
+
+export const DataColorSwitch = (name: string) => {
+    switch (name) {
+        case 'TypeScript':
+            return 'rgba(44, 109, 188, 0.6)';
+        case 'JavaScript':
+            return 'rgba(238, 219, 87, 0.6)';
+        case 'SCSS':
+            return 'rgba(192, 72, 129, 0.6)';
+        case 'Shell':
+            return 'rgba(122, 220, 78, 0.6)';
+        case 'CSS':
+            return 'rgba(77, 53, 111, 0.6)';
+        case 'HTML':
+            return 'rgba(225, 66, 40, 0.6)';
+        default:
+            return 'rgba(255, 255, 255, 0.6)';
+    }
+};

--- a/src/component/molecules/DashBoardCardChart/index.tsx
+++ b/src/component/molecules/DashBoardCardChart/index.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+
+import { useStore } from '@/store';
+
+import { Line, Doughnut, Pie, Chart } from 'react-chartjs-2';
+
+import { DashBoardCard, RepositoryList, RepositoryListContent } from './style';
+import { DataColorSwitch } from '@/component/molecules/DashBoardCardChart/DataColor';
+
+interface DataTypes {
+    labels: string[];
+    datasets: [
+        {
+            type: string;
+            label: string;
+            backgroundColor: any[];
+            data: number[];
+            width: string;
+            borderWidth: number;
+        },
+    ];
+}
+
+export const DashBoardCardChart = () => {
+    const { language } = useStore();
+
+    const createPercentValue = () => {
+        const objectValues: number[] = Object.values(language.language);
+        let allValue: number = 0;
+        let percentValue: number = 0;
+        let percentValueArray: number[] = [];
+        for (const bb of objectValues) {
+            allValue += bb;
+        }
+        objectValues.map(item => {
+            percentValue = (item / allValue) * 100;
+            percentValueArray.push(Math.round(percentValue));
+        });
+        return percentValueArray;
+    };
+
+    const createChartLabel = () => {
+        const objectKeys: string[] = Object.keys(language.language);
+        let objectKeysArray: string[] = [];
+        objectKeys.map(item => {
+            objectKeysArray.push(item);
+        });
+        return objectKeysArray;
+    };
+
+    const createBackgroundColor = () => {
+        let backgroundColorArray: any = [];
+        if (createChartLabel()) {
+            createChartLabel().map(item => {
+                backgroundColorArray.push(DataColorSwitch(item));
+            });
+        }
+        return backgroundColorArray;
+    };
+
+    const data: DataTypes = {
+        labels: createChartLabel(),
+        datasets: [
+            {
+                type: 'doughnut',
+                label: 'Dataset 1',
+                backgroundColor: createBackgroundColor(),
+                borderWidth: 1,
+                data: createPercentValue(),
+                width: '150px',
+            },
+        ],
+    };
+
+    return (
+        <DashBoardCard>
+            {/*@ts-ignore*/}
+            <Doughnut data={data} width={100} height={50} options={{ maintainAspectRatio: false }} type={'doughnut'} />
+        </DashBoardCard>
+    );
+};

--- a/src/component/molecules/DashBoardCardChart/style.ts
+++ b/src/component/molecules/DashBoardCardChart/style.ts
@@ -1,0 +1,35 @@
+import { styled } from '@stitches/react';
+
+export const DashBoardCard = styled('div', {
+    width: '100%',
+    height: 'auto',
+    margin: '10px',
+    padding: '10px',
+    backgroundColor: 'rgb(21, 76, 189)',
+    borderRadius: '8px',
+    boxShadow: '0 5px 10px 5px rgba(0, 0, 0, 0.1)',
+
+    variants: {
+        size: {
+            smaill: {
+                maxWidth: '300px',
+            },
+            medium: {
+                maxWidth: '500px',
+            },
+            large: {
+                maxWidth: '700px',
+            },
+        },
+    },
+});
+
+export const RepositoryList = styled('div', {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+});
+
+export const RepositoryListContent = styled('div', {
+    flex: '0 1 1',
+});

--- a/src/component/molecules/DashBoardCardRepo/index.tsx
+++ b/src/component/molecules/DashBoardCardRepo/index.tsx
@@ -1,37 +1,35 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { DashBoardCard, RepositoryList, RepositoryListContent } from './style';
+import { DashBoardCard, RepositoryList } from './style';
 
 import { useStore } from '@/store';
 
 // Atoms
-// import { CardTitleAtoms } from '@/component/atoms/CardTitle';
 import { TextAtoms } from '@/component/atoms/Text';
 import { IconAtoms } from '@/component/atoms/Icon';
 
+interface test {
+    id: number;
+    label: string;
+    data: [];
+}
+
 export const DashBoardCardRepo = () => {
-    const { auth } = useStore();
+    const { auth, language } = useStore();
 
     // 날짜순으로 정렬 후 인덱스 0~5개만 가지고 옴
     const orderedDate = auth.repository
         ?.sort((a, b) => new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime())
         .slice(0, 5);
 
-    const CardTitle = [
-        {
-            title: '레포지토리 이름',
-        },
-        {
-            title: '업데이트 날짜',
-        },
-        {
-            title: 'Github 이동',
-        },
-    ];
-
-    console.log(orderedDate);
+    useEffect(() => {
+        // Default로 첫번째 data를 호출
+        if (orderedDate) {
+            language.getLanguage?.(orderedDate[0].languages_url);
+        }
+    }, []);
 
     return (
         <>
@@ -44,7 +42,8 @@ export const DashBoardCardRepo = () => {
                                 text={item.name}
                                 textType={'explain'}
                                 position={'left'}
-                                css={{ margin: '5px 0' }}
+                                css={{ margin: '5px 0', cursor: 'pointer' }}
+                                onClick={() => language.getLanguage?.(item.languages_url)}
                             />
                             <TextAtoms text={item.pushed_at.slice(0, -10)} textType={'explain'} />
 

--- a/src/component/templates/Main/index.tsx
+++ b/src/component/templates/Main/index.tsx
@@ -3,12 +3,16 @@ import React from 'react';
 import { HeaderOrganisms } from '@/component/organisms/Header';
 
 import { DashBoardCardRepo } from '@/component/molecules/DashBoardCardRepo';
+import { DashBoardCardChart } from '@/component/molecules/DashBoardCardChart';
 
 export const Main = () => {
     return (
         <>
             <HeaderOrganisms />
-            <DashBoardCardRepo />
+            <div style={{ display: 'flex' }}>
+                <DashBoardCardRepo />
+                <DashBoardCardChart />
+            </div>
         </>
     );
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,11 +2,23 @@ import React, { useState, useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import '../styles/common/index.scss';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    BarElement,
+    ArcElement,
+    Tooltip,
+} from 'chart.js';
 
 import { DefaultLayout } from '@/component/atoms/Layout';
 
+// ChartJS 생성자 함수에 플러그인을 등록합니다.
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip);
+
 function MyApp({ Component, pageProps }: AppProps) {
-    const router = useRouter();
     const [isSSR, setIsSSR] = useState(true);
 
     useEffect(() => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,8 @@
 // store
 import { useStoreAuth } from './storeAuth';
+import { useStoreLanguage } from './storeLanguage';
 
 export const useStore = () => ({
     auth: useStoreAuth(),
+    language: useStoreLanguage(),
 });

--- a/src/store/storeAuth.d.ts
+++ b/src/store/storeAuth.d.ts
@@ -12,6 +12,7 @@ export interface StoreAuthTypes {
                   pushed_at: string;
                   html_url: string;
                   issue_open: number;
+                  languages_url: string;
               },
           ]
         | null;
@@ -39,6 +40,7 @@ export interface getUserRepositoryResponseTypes {
             pushed_at: string;
             html_url: string;
             issue_open: number;
+            languages_url: string;
         },
     ];
 }

--- a/src/store/storeLanguage.d.ts
+++ b/src/store/storeLanguage.d.ts
@@ -1,0 +1,6 @@
+export interface StoreLanguageTypes {
+    // TODO: any type fix
+    language: any;
+
+    getLanguage?: (payload: string) => void;
+}

--- a/src/store/storeLanguage.ts
+++ b/src/store/storeLanguage.ts
@@ -1,0 +1,19 @@
+import create from 'zustand';
+import { StoreLanguageTypes } from './storeLanguage.d';
+import axios from 'axios';
+
+const initialState: StoreLanguageTypes = {
+    language: '',
+};
+
+export const useStoreLanguage = create<StoreLanguageTypes>(set => ({
+    ...initialState,
+    getLanguage: async payload => {
+        try {
+            const response = await axios.get(payload);
+            set(() => ({
+                language: response.data,
+            }));
+        } catch {}
+    },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,6 +728,11 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chart.js@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
+  integrity sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==
+
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -2318,6 +2323,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+react-chartjs-2@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-4.3.1.tgz#9941e7397fb963f28bb557addb401e9ff96c6681"
+  integrity sha512-5i3mjP6tU7QSn0jvb8I4hudTzHJqS8l00ORJnVwI2sYu0ihpj83Lv2YzfxunfxTZkscKvZu2F2w9LkwNBhj6xA==
 
 react-dom@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
### 이슈

#21 Chart.js & chart-reactjs-2 package add

### 작업 내용

- github language api를 통해서 클릭하는 레포지토리의 사용 언어를 받아오도록 작업
- 추가한 패키지를 사용해서 도넛 형태의 차트를 생성
- 레포지토리 이름을 클릭 할 때마다 데이터가 바뀌도록 작업
- 이름에 따른 컬러가 나오도록 작업
- 내려오는 값을 백분율로 계산해주는 식 작업
